### PR TITLE
chore: update dependabot to conform to conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: 'daily'
     commit-message:
-      prefix: 'chore(github-actions):'
+      prefix: 'chore(actions):'
 
   - package-ecosystem: 'npm'
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,13 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    commit-message:
+      prefix: 'chore(github-actions):'
 
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'daily'
+    commit-message:
+      prefix: 'chore(deps):'
+      prefix-development: 'chore(devDeps):'

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -29,7 +29,6 @@ jobs:
   check_pr_title:
     name: Check PR Title
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot'
     steps:
       - uses: amannn/action-semantic-pull-request@v3.4.0
         env:
@@ -48,3 +47,7 @@ jobs:
             chore
             revert
             removal
+          # scopes: |
+          #   deps
+          #   devDeps
+          #   github-actions

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -29,7 +29,7 @@ jobs:
   check_pr_title:
     name: Check PR Title
     runs-on: ubuntu-latest
-    if: github.actor != 'renovate-bot' && github.actor != 'renovate[bot]'
+    if: github.actor != 'dependabot'
     steps:
       - uses: amannn/action-semantic-pull-request@v3.4.0
         env:


### PR DESCRIPTION
This makes it to where we can still run the PR Title check for all PRs (including dependabot)